### PR TITLE
Redesign example app into comprehensive SDK showcase

### DIFF
--- a/example/convex/example.test.ts
+++ b/example/convex/example.test.ts
@@ -1,20 +1,922 @@
-import { describe, expect, test } from "vitest";
-import { api } from "./_generated/api";
+/// <reference types="vite/client" />
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
+import { initConvexTest } from "./setup.test.js";
+import { api } from "./_generated/api.js";
 
-describe("example", () => {
-  test("mutation functions exist", () => {
-    expect(api.example.testCapture).toBeDefined();
-    expect(api.example.testIdentify).toBeDefined();
-    expect(api.example.testGroupIdentify).toBeDefined();
-    expect(api.example.testAlias).toBeDefined();
+// Collect all fetch calls for assertion
+let fetchCalls: Array<{ url: string; body: unknown }> = [];
+
+function mockFetch(responseByUrl?: Record<string, unknown>) {
+  fetchCalls = [];
+  return vi.fn(async (url: string | URL, init?: RequestInit) => {
+    const urlStr = url.toString();
+    let body: unknown;
+    if (init?.body) {
+      let rawText: string;
+      if (init.body instanceof Blob) {
+        const headers = init.headers as Record<string, string> | undefined;
+        if (headers?.["Content-Encoding"] === "gzip") {
+          const ds = new DecompressionStream("gzip");
+          rawText = await new Response(
+            init.body.stream().pipeThrough(ds),
+          ).text();
+        } else {
+          rawText = await init.body.text();
+        }
+      } else {
+        rawText = init.body as string;
+      }
+      try {
+        body = JSON.parse(rawText);
+      } catch {
+        body = rawText;
+      }
+    }
+    fetchCalls.push({ url: urlStr, body });
+
+    if (responseByUrl) {
+      for (const [pattern, response] of Object.entries(responseByUrl)) {
+        if (urlStr.includes(pattern)) {
+          return new Response(JSON.stringify(response), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          });
+        }
+      }
+    }
+
+    return new Response(JSON.stringify({ status: 1 }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  });
+}
+
+function batchCalls() {
+  return fetchCalls.filter((c) => c.url.includes("/batch"));
+}
+
+function flagsCalls() {
+  return fetchCalls.filter((c) => c.url.includes("/flags"));
+}
+
+// Extract the first event from the first batch call
+function firstBatchEvent(): Record<string, unknown> {
+  const batches = batchCalls();
+  const batch = batches[0]?.body as { batch: Record<string, unknown>[] };
+  return batch?.batch?.[0] ?? {};
+}
+
+describe("capture", () => {
+  beforeEach(() => {
+    process.env.POSTHOG_API_KEY = "phc_test_key";
+    process.env.POSTHOG_HOST = "https://test.posthog.com";
   });
 
-  test("feature flag action functions exist", () => {
-    expect(api.example.testGetFeatureFlag).toBeDefined();
-    expect(api.example.testIsFeatureEnabled).toBeDefined();
-    expect(api.example.testGetFeatureFlagPayload).toBeDefined();
-    expect(api.example.testGetFeatureFlagResult).toBeDefined();
-    expect(api.example.testGetAllFlags).toBeDefined();
-    expect(api.example.testGetAllFlagsAndPayloads).toBeDefined();
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    delete process.env.POSTHOG_API_KEY;
+    delete process.env.POSTHOG_HOST;
+    fetchCalls = [];
+  });
+
+  test("sends event to PostHog API with correct distinct_id and event name", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("fetch", mockFetch());
+    const t = initConvexTest();
+
+    const result = await t.mutation(api.example.testCapture, {
+      distinctId: "user-123",
+      event: "button_clicked",
+    });
+    expect(result).toEqual({ success: true });
+
+    vi.runAllTimers();
+    await t.finishInProgressScheduledFunctions();
+
+    expect(batchCalls().length).toBeGreaterThanOrEqual(1);
+    const batch = batchCalls()[0].body as { api_key: string };
+    expect(batch.api_key).toBe("phc_test_key");
+
+    const event = firstBatchEvent();
+    expect(event.distinct_id).toBe("user-123");
+    expect(event.event).toBe("button_clicked");
+  });
+
+  test("sends properties and groups", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("fetch", mockFetch());
+    const t = initConvexTest();
+
+    await t.mutation(api.example.testCapture, {
+      distinctId: "user-456",
+      event: "purchase",
+      properties: { plan: "pro", amount: 99 },
+      groups: { company: "acme" },
+    });
+
+    vi.runAllTimers();
+    await t.finishInProgressScheduledFunctions();
+
+    const event = firstBatchEvent();
+    const props = event.properties as Record<string, unknown>;
+    expect(props.plan).toBe("pro");
+    expect(props.amount).toBe(99);
+    expect(props.$groups).toEqual({ company: "acme" });
+  });
+
+  test("beforeSend enriches properties with environment", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("fetch", mockFetch());
+    const t = initConvexTest();
+
+    await t.mutation(api.example.testCapture, {
+      distinctId: "user-123",
+      event: "test",
+      properties: { foo: "bar" },
+    });
+
+    vi.runAllTimers();
+    await t.finishInProgressScheduledFunctions();
+
+    const props = firstBatchEvent().properties as Record<string, unknown>;
+    expect(props.environment).toBe("example-app");
+    expect(props.foo).toBe("bar");
+  });
+
+  test("sends disableGeoip flag", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("fetch", mockFetch());
+    const t = initConvexTest();
+
+    await t.mutation(api.example.testCapture, {
+      distinctId: "user-123",
+      event: "test",
+      disableGeoip: true,
+    });
+
+    vi.runAllTimers();
+    await t.finishInProgressScheduledFunctions();
+
+    const props = firstBatchEvent().properties as Record<string, unknown>;
+    expect(props.$geoip_disable).toBe(true);
+  });
+
+  test("sends custom uuid", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("fetch", mockFetch());
+    const t = initConvexTest();
+
+    await t.mutation(api.example.testCapture, {
+      distinctId: "user-123",
+      event: "test",
+      uuid: "custom-uuid-abc",
+    });
+
+    vi.runAllTimers();
+    await t.finishInProgressScheduledFunctions();
+
+    const event = firstBatchEvent();
+    expect(event.uuid).toBe("custom-uuid-abc");
+  });
+
+  test("sends timestamp", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("fetch", mockFetch());
+    const t = initConvexTest();
+
+    await t.mutation(api.example.testCapture, {
+      distinctId: "user-123",
+      event: "test",
+      timestamp: "2024-06-15T12:00:00Z",
+    });
+
+    vi.runAllTimers();
+    await t.finishInProgressScheduledFunctions();
+
+    const event = firstBatchEvent();
+    expect(event.timestamp).toContain("2024-06-15");
+  });
+});
+
+describe("identify", () => {
+  beforeEach(() => {
+    process.env.POSTHOG_API_KEY = "phc_test_key";
+    process.env.POSTHOG_HOST = "https://test.posthog.com";
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    delete process.env.POSTHOG_API_KEY;
+    delete process.env.POSTHOG_HOST;
+    fetchCalls = [];
+  });
+
+  test("sends $identify event", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("fetch", mockFetch());
+    const t = initConvexTest();
+
+    const result = await t.mutation(api.example.testIdentify, {
+      distinctId: "user-123",
+    });
+    expect(result).toEqual({ success: true });
+
+    vi.runAllTimers();
+    await t.finishInProgressScheduledFunctions();
+
+    expect(batchCalls().length).toBeGreaterThanOrEqual(1);
+    const event = firstBatchEvent();
+    expect(event.event).toBe("$identify");
+    expect(event.distinct_id).toBe("user-123");
+  });
+
+  test("sends user properties", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("fetch", mockFetch());
+    const t = initConvexTest();
+
+    await t.mutation(api.example.testIdentify, {
+      distinctId: "user-123",
+      properties: {
+        name: "Test User",
+        email: "test@example.com",
+      },
+    });
+
+    vi.runAllTimers();
+    await t.finishInProgressScheduledFunctions();
+
+    const event = firstBatchEvent();
+    // posthog-node puts properties into $set inside event.properties
+    const props = event.properties as Record<string, unknown>;
+    const $set = props.$set as Record<string, unknown>;
+    expect($set.name).toBe("Test User");
+    expect($set.email).toBe("test@example.com");
+  });
+
+  test("sends disableGeoip", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("fetch", mockFetch());
+    const t = initConvexTest();
+
+    await t.mutation(api.example.testIdentify, {
+      distinctId: "user-123",
+      disableGeoip: true,
+    });
+
+    vi.runAllTimers();
+    await t.finishInProgressScheduledFunctions();
+
+    const props = firstBatchEvent().properties as Record<string, unknown>;
+    expect(props.$geoip_disable).toBe(true);
+  });
+});
+
+describe("groupIdentify", () => {
+  beforeEach(() => {
+    process.env.POSTHOG_API_KEY = "phc_test_key";
+    process.env.POSTHOG_HOST = "https://test.posthog.com";
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    delete process.env.POSTHOG_API_KEY;
+    delete process.env.POSTHOG_HOST;
+    fetchCalls = [];
+  });
+
+  test("sends $groupidentify event with group type and key", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("fetch", mockFetch());
+    const t = initConvexTest();
+
+    const result = await t.mutation(api.example.testGroupIdentify, {
+      groupType: "company",
+      groupKey: "acme",
+    });
+    expect(result).toEqual({ success: true });
+
+    vi.runAllTimers();
+    await t.finishInProgressScheduledFunctions();
+
+    expect(batchCalls().length).toBeGreaterThanOrEqual(1);
+    const event = firstBatchEvent();
+    expect(event.event).toBe("$groupidentify");
+    const props = event.properties as Record<string, unknown>;
+    expect(props.$group_type).toBe("company");
+    expect(props.$group_key).toBe("acme");
+  });
+
+  test("sends group properties via $group_set", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("fetch", mockFetch());
+    const t = initConvexTest();
+
+    await t.mutation(api.example.testGroupIdentify, {
+      groupType: "company",
+      groupKey: "acme",
+      properties: { industry: "Technology", size: 100 },
+    });
+
+    vi.runAllTimers();
+    await t.finishInProgressScheduledFunctions();
+
+    const props = firstBatchEvent().properties as Record<string, unknown>;
+    const groupSet = props.$group_set as Record<string, unknown>;
+    expect(groupSet.industry).toBe("Technology");
+    expect(groupSet.size).toBe(100);
+  });
+
+  test("uses distinctId override when provided", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("fetch", mockFetch());
+    const t = initConvexTest();
+
+    await t.mutation(api.example.testGroupIdentify, {
+      groupType: "company",
+      groupKey: "acme",
+      distinctId: "override-user",
+    });
+
+    vi.runAllTimers();
+    await t.finishInProgressScheduledFunctions();
+
+    expect(firstBatchEvent().distinct_id).toBe("override-user");
+  });
+});
+
+describe("alias", () => {
+  beforeEach(() => {
+    process.env.POSTHOG_API_KEY = "phc_test_key";
+    process.env.POSTHOG_HOST = "https://test.posthog.com";
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    delete process.env.POSTHOG_API_KEY;
+    delete process.env.POSTHOG_HOST;
+    fetchCalls = [];
+  });
+
+  test("sends $create_alias event", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("fetch", mockFetch());
+    const t = initConvexTest();
+
+    const result = await t.mutation(api.example.testAlias, {
+      distinctId: "user-123",
+      alias: "anon-456",
+    });
+    expect(result).toEqual({ success: true });
+
+    vi.runAllTimers();
+    await t.finishInProgressScheduledFunctions();
+
+    expect(batchCalls().length).toBeGreaterThanOrEqual(1);
+    const event = firstBatchEvent();
+    expect(event.event).toBe("$create_alias");
+    const props = event.properties as Record<string, unknown>;
+    expect(props.distinct_id).toBe("user-123");
+    expect(props.alias).toBe("anon-456");
+  });
+
+  test("sends disableGeoip", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("fetch", mockFetch());
+    const t = initConvexTest();
+
+    await t.mutation(api.example.testAlias, {
+      distinctId: "user-123",
+      alias: "anon-456",
+      disableGeoip: true,
+    });
+
+    vi.runAllTimers();
+    await t.finishInProgressScheduledFunctions();
+
+    const props = firstBatchEvent().properties as Record<string, unknown>;
+    expect(props.$geoip_disable).toBe(true);
+  });
+});
+
+describe("captureException", () => {
+  beforeEach(() => {
+    process.env.POSTHOG_API_KEY = "phc_test_key";
+    process.env.POSTHOG_HOST = "https://test.posthog.com";
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    delete process.env.POSTHOG_API_KEY;
+    delete process.env.POSTHOG_HOST;
+    fetchCalls = [];
+  });
+
+  test("sends $exception event with Error object", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("fetch", mockFetch());
+    const t = initConvexTest();
+
+    const result = await t.mutation(api.example.testCaptureException, {
+      errorMessage: "Something went wrong",
+      errorType: "error",
+    });
+    expect(result).toEqual({ success: true });
+
+    vi.runAllTimers();
+    await t.finishInProgressScheduledFunctions();
+
+    expect(batchCalls().length).toBeGreaterThanOrEqual(1);
+    const event = firstBatchEvent();
+    expect(event.event).toBe("$exception");
+    const props = event.properties as Record<string, unknown>;
+    // posthog-node v5 uses $exception_list instead of $exception_message
+    const exceptionList = props.$exception_list as Array<{
+      value: string;
+      type: string;
+    }>;
+    expect(exceptionList[0].value).toBe("Something went wrong");
+  });
+
+  test("sends $exception event with string error", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("fetch", mockFetch());
+    const t = initConvexTest();
+
+    await t.mutation(api.example.testCaptureException, {
+      errorMessage: "string error",
+      errorType: "string",
+    });
+
+    vi.runAllTimers();
+    await t.finishInProgressScheduledFunctions();
+
+    const props = firstBatchEvent().properties as Record<string, unknown>;
+    const exceptionList = props.$exception_list as Array<{
+      value: string;
+    }>;
+    expect(exceptionList[0].value).toBe("string error");
+  });
+
+  test("sends $exception event with object error", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("fetch", mockFetch());
+    const t = initConvexTest();
+
+    await t.mutation(api.example.testCaptureException, {
+      errorMessage: "obj error",
+      errorType: "object",
+    });
+
+    vi.runAllTimers();
+    await t.finishInProgressScheduledFunctions();
+
+    const props = firstBatchEvent().properties as Record<string, unknown>;
+    const exceptionList = props.$exception_list as Array<{
+      value: string;
+    }>;
+    expect(exceptionList[0].value).toBe("obj error");
+  });
+
+  test("includes additional properties", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("fetch", mockFetch());
+    const t = initConvexTest();
+
+    await t.mutation(api.example.testCaptureException, {
+      errorMessage: "test",
+      additionalProperties: { page: "/checkout", step: 3 },
+    });
+
+    vi.runAllTimers();
+    await t.finishInProgressScheduledFunctions();
+
+    const props = firstBatchEvent().properties as Record<string, unknown>;
+    expect(props.page).toBe("/checkout");
+    expect(props.step).toBe(3);
+  });
+
+  test("uses distinctId when provided", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("fetch", mockFetch());
+    const t = initConvexTest();
+
+    await t.mutation(api.example.testCaptureException, {
+      errorMessage: "test",
+      distinctId: "specific-user",
+    });
+
+    vi.runAllTimers();
+    await t.finishInProgressScheduledFunctions();
+
+    expect(firstBatchEvent().distinct_id).toBe("specific-user");
+  });
+});
+
+const flagsResponse = (
+  flags: Record<string, unknown> = {},
+  payloads: Record<string, unknown> = {},
+) => ({
+  "/flags": {
+    featureFlags: flags,
+    featureFlagPayloads: payloads,
+  },
+});
+
+describe("getFeatureFlag", () => {
+  beforeEach(() => {
+    process.env.POSTHOG_API_KEY = "phc_test_key";
+    process.env.POSTHOG_HOST = "https://test.posthog.com";
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    delete process.env.POSTHOG_API_KEY;
+    delete process.env.POSTHOG_HOST;
+    fetchCalls = [];
+  });
+
+  test("returns flag value", async () => {
+    vi.stubGlobal(
+      "fetch",
+      mockFetch(flagsResponse({ "test-flag": "variant-a" })),
+    );
+    const t = initConvexTest();
+
+    const result = await t.action(api.example.testGetFeatureFlag, {
+      distinctId: "user-123",
+      flagKey: "test-flag",
+    });
+
+    expect(result).toEqual({ flagKey: "test-flag", value: "variant-a" });
+  });
+
+  test("returns boolean flag", async () => {
+    vi.stubGlobal(
+      "fetch",
+      mockFetch(flagsResponse({ "bool-flag": true })),
+    );
+    const t = initConvexTest();
+
+    const result = await t.action(api.example.testGetFeatureFlag, {
+      distinctId: "user-123",
+      flagKey: "bool-flag",
+    });
+
+    expect(result).toEqual({ flagKey: "bool-flag", value: true });
+  });
+
+  test("returns null for non-existent flag", async () => {
+    vi.stubGlobal("fetch", mockFetch(flagsResponse()));
+    const t = initConvexTest();
+
+    const result = await t.action(api.example.testGetFeatureFlag, {
+      distinctId: "user-123",
+      flagKey: "missing",
+    });
+
+    expect(result).toEqual({ flagKey: "missing", value: null });
+  });
+
+  test("sends groups and person properties to /flags", async () => {
+    vi.stubGlobal(
+      "fetch",
+      mockFetch(flagsResponse({ "test-flag": true })),
+    );
+    const t = initConvexTest();
+
+    await t.action(api.example.testGetFeatureFlag, {
+      distinctId: "user-123",
+      flagKey: "test-flag",
+      groups: { company: "acme" },
+      personProperties: { email: "test@example.com" },
+      groupProperties: { company: { industry: "tech" } },
+    });
+
+    const calls = flagsCalls();
+    expect(calls.length).toBeGreaterThanOrEqual(1);
+    const body = calls[0].body as Record<string, unknown>;
+    expect(body.distinct_id).toBe("user-123");
+    expect(body.groups).toEqual({ company: "acme" });
+    expect(body.person_properties).toMatchObject({
+      email: "test@example.com",
+    });
+    expect(body.group_properties).toMatchObject({
+      company: { industry: "tech" },
+    });
+  });
+});
+
+describe("isFeatureEnabled", () => {
+  beforeEach(() => {
+    process.env.POSTHOG_API_KEY = "phc_test_key";
+    process.env.POSTHOG_HOST = "https://test.posthog.com";
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    delete process.env.POSTHOG_API_KEY;
+    delete process.env.POSTHOG_HOST;
+    fetchCalls = [];
+  });
+
+  test("returns true for enabled flag", async () => {
+    vi.stubGlobal(
+      "fetch",
+      mockFetch(flagsResponse({ "test-flag": true })),
+    );
+    const t = initConvexTest();
+
+    const result = await t.action(api.example.testIsFeatureEnabled, {
+      distinctId: "user-123",
+      flagKey: "test-flag",
+    });
+
+    expect(result).toEqual({ flagKey: "test-flag", enabled: true });
+  });
+
+  test("returns true for string variant (truthy)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      mockFetch(flagsResponse({ "test-flag": "variant-a" })),
+    );
+    const t = initConvexTest();
+
+    const result = await t.action(api.example.testIsFeatureEnabled, {
+      distinctId: "user-123",
+      flagKey: "test-flag",
+    });
+
+    expect(result).toEqual({ flagKey: "test-flag", enabled: true });
+  });
+
+  test("returns null for non-existent flag", async () => {
+    vi.stubGlobal("fetch", mockFetch(flagsResponse()));
+    const t = initConvexTest();
+
+    const result = await t.action(api.example.testIsFeatureEnabled, {
+      distinctId: "user-123",
+      flagKey: "missing",
+    });
+
+    expect(result).toEqual({ flagKey: "missing", enabled: null });
+  });
+});
+
+describe("getFeatureFlagPayload", () => {
+  beforeEach(() => {
+    process.env.POSTHOG_API_KEY = "phc_test_key";
+    process.env.POSTHOG_HOST = "https://test.posthog.com";
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    delete process.env.POSTHOG_API_KEY;
+    delete process.env.POSTHOG_HOST;
+    fetchCalls = [];
+  });
+
+  test("returns payload for flag", async () => {
+    vi.stubGlobal(
+      "fetch",
+      mockFetch(
+        flagsResponse({ "test-flag": true }, { "test-flag": { key: "value" } }),
+      ),
+    );
+    const t = initConvexTest();
+
+    const result = await t.action(api.example.testGetFeatureFlagPayload, {
+      distinctId: "user-123",
+      flagKey: "test-flag",
+    });
+
+    expect(result).toEqual({
+      flagKey: "test-flag",
+      payload: { key: "value" },
+    });
+  });
+
+  test("returns null when no payload exists", async () => {
+    vi.stubGlobal(
+      "fetch",
+      mockFetch(flagsResponse({ "test-flag": true })),
+    );
+    const t = initConvexTest();
+
+    const result = await t.action(api.example.testGetFeatureFlagPayload, {
+      distinctId: "user-123",
+      flagKey: "test-flag",
+    });
+
+    expect(result).toEqual({ flagKey: "test-flag", payload: null });
+  });
+
+  test("accepts matchValue parameter", async () => {
+    vi.stubGlobal(
+      "fetch",
+      mockFetch(
+        flagsResponse(
+          { "test-flag": "variant-a" },
+          { "test-flag": "payload-data" },
+        ),
+      ),
+    );
+    const t = initConvexTest();
+
+    const result = await t.action(api.example.testGetFeatureFlagPayload, {
+      distinctId: "user-123",
+      flagKey: "test-flag",
+      matchValue: "variant-a",
+    });
+
+    expect(result.flagKey).toBe("test-flag");
+    expect(result.payload).toBe("payload-data");
+  });
+});
+
+describe("getFeatureFlagResult", () => {
+  beforeEach(() => {
+    process.env.POSTHOG_API_KEY = "phc_test_key";
+    process.env.POSTHOG_HOST = "https://test.posthog.com";
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    delete process.env.POSTHOG_API_KEY;
+    delete process.env.POSTHOG_HOST;
+    fetchCalls = [];
+  });
+
+  test("returns full result with variant and payload", async () => {
+    vi.stubGlobal(
+      "fetch",
+      mockFetch(
+        flagsResponse(
+          { "test-flag": "variant-a" },
+          { "test-flag": { config: true } },
+        ),
+      ),
+    );
+    const t = initConvexTest();
+
+    const result = await t.action(api.example.testGetFeatureFlagResult, {
+      distinctId: "user-123",
+      flagKey: "test-flag",
+    });
+
+    expect(result.flagKey).toBe("test-flag");
+    expect(result.result).not.toBeNull();
+    expect(result.result!.key).toBe("test-flag");
+    expect(result.result!.enabled).toBe(true);
+    expect(result.result!.variant).toBe("variant-a");
+    expect(result.result!.payload).toEqual({ config: true });
+  });
+
+  test("returns null for non-existent flag", async () => {
+    vi.stubGlobal("fetch", mockFetch(flagsResponse()));
+    const t = initConvexTest();
+
+    const result = await t.action(api.example.testGetFeatureFlagResult, {
+      distinctId: "user-123",
+      flagKey: "missing",
+    });
+
+    expect(result).toEqual({ flagKey: "missing", result: null });
+  });
+});
+
+describe("getAllFlags", () => {
+  beforeEach(() => {
+    process.env.POSTHOG_API_KEY = "phc_test_key";
+    process.env.POSTHOG_HOST = "https://test.posthog.com";
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    delete process.env.POSTHOG_API_KEY;
+    delete process.env.POSTHOG_HOST;
+    fetchCalls = [];
+  });
+
+  test("returns all flags", async () => {
+    vi.stubGlobal(
+      "fetch",
+      mockFetch(
+        flagsResponse({
+          "flag-a": true,
+          "flag-b": "variant-1",
+          "flag-c": false,
+        }),
+      ),
+    );
+    const t = initConvexTest();
+
+    const result = await t.action(api.example.testGetAllFlags, {
+      distinctId: "user-123",
+    });
+
+    expect(result.flags).toEqual({
+      "flag-a": true,
+      "flag-b": "variant-1",
+      "flag-c": false,
+    });
+  });
+
+  test("sends groups and properties to /flags", async () => {
+    vi.stubGlobal(
+      "fetch",
+      mockFetch(flagsResponse({ "test-flag": true })),
+    );
+    const t = initConvexTest();
+
+    await t.action(api.example.testGetAllFlags, {
+      distinctId: "user-123",
+      groups: { company: "acme" },
+      personProperties: { plan: "pro" },
+      groupProperties: { company: { size: "100" } },
+    });
+
+    const body = flagsCalls()[0].body as Record<string, unknown>;
+    expect(body.groups).toEqual({ company: "acme" });
+    expect(body.person_properties).toMatchObject({ plan: "pro" });
+    expect(body.group_properties).toMatchObject({ company: { size: "100" } });
+  });
+
+  test("accepts flagKeys filter", async () => {
+    vi.stubGlobal(
+      "fetch",
+      mockFetch(flagsResponse({ "flag-a": true })),
+    );
+    const t = initConvexTest();
+
+    const result = await t.action(api.example.testGetAllFlags, {
+      distinctId: "user-123",
+      flagKeys: ["flag-a", "flag-b"],
+    });
+
+    expect(result.flags).toBeDefined();
+  });
+});
+
+describe("getAllFlagsAndPayloads", () => {
+  beforeEach(() => {
+    process.env.POSTHOG_API_KEY = "phc_test_key";
+    process.env.POSTHOG_HOST = "https://test.posthog.com";
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    delete process.env.POSTHOG_API_KEY;
+    delete process.env.POSTHOG_HOST;
+    fetchCalls = [];
+  });
+
+  test("returns flags and payloads", async () => {
+    vi.stubGlobal(
+      "fetch",
+      mockFetch(
+        flagsResponse(
+          { "flag-a": true, "flag-b": "variant" },
+          { "flag-a": { config: "value" } },
+        ),
+      ),
+    );
+    const t = initConvexTest();
+
+    const result = await t.action(api.example.testGetAllFlagsAndPayloads, {
+      distinctId: "user-123",
+    });
+
+    expect(result.featureFlags).toEqual({
+      "flag-a": true,
+      "flag-b": "variant",
+    });
+    expect(result.featureFlagPayloads).toEqual({
+      "flag-a": { config: "value" },
+    });
+  });
+
+  test("accepts flagKeys filter", async () => {
+    vi.stubGlobal(
+      "fetch",
+      mockFetch(
+        flagsResponse({ "flag-a": true }, { "flag-a": "payload" }),
+      ),
+    );
+    const t = initConvexTest();
+
+    const result = await t.action(api.example.testGetAllFlagsAndPayloads, {
+      distinctId: "user-123",
+      flagKeys: ["flag-a"],
+    });
+
+    expect(result.featureFlags).toBeDefined();
+    expect(result.featureFlagPayloads).toBeDefined();
   });
 });

--- a/example/convex/example.ts
+++ b/example/convex/example.ts
@@ -9,13 +9,22 @@ export const testCapture = mutation({
     distinctId: v.string(),
     event: v.string(),
     properties: v.optional(v.any()),
+    groups: v.optional(v.any()),
+    sendFeatureFlags: v.optional(v.boolean()),
+    timestamp: v.optional(v.string()),
+    uuid: v.optional(v.string()),
+    disableGeoip: v.optional(v.boolean()),
   },
   handler: async (ctx, args) => {
     await posthog.capture(ctx, {
       distinctId: args.distinctId,
       event: args.event,
       properties: args.properties,
-      groups: { company: "test-corp" },
+      groups: args.groups,
+      sendFeatureFlags: args.sendFeatureFlags,
+      timestamp: args.timestamp ? new Date(args.timestamp) : undefined,
+      uuid: args.uuid || undefined,
+      disableGeoip: args.disableGeoip,
     });
     return { success: true };
   },
@@ -25,11 +34,13 @@ export const testIdentify = mutation({
   args: {
     distinctId: v.string(),
     properties: v.optional(v.any()),
+    disableGeoip: v.optional(v.boolean()),
   },
   handler: async (ctx, args) => {
     await posthog.identify(ctx, {
       distinctId: args.distinctId,
-      properties: args.properties ?? { name: "Test User", plan: "pro" },
+      properties: args.properties,
+      disableGeoip: args.disableGeoip,
     });
     return { success: true };
   },
@@ -40,12 +51,16 @@ export const testGroupIdentify = mutation({
     groupType: v.string(),
     groupKey: v.string(),
     properties: v.optional(v.any()),
+    distinctId: v.optional(v.string()),
+    disableGeoip: v.optional(v.boolean()),
   },
   handler: async (ctx, args) => {
     await posthog.groupIdentify(ctx, {
       groupType: args.groupType,
       groupKey: args.groupKey,
-      properties: args.properties ?? { industry: "Technology" },
+      properties: args.properties,
+      distinctId: args.distinctId || undefined,
+      disableGeoip: args.disableGeoip,
     });
     return { success: true };
   },
@@ -55,11 +70,45 @@ export const testAlias = mutation({
   args: {
     distinctId: v.string(),
     alias: v.string(),
+    disableGeoip: v.optional(v.boolean()),
   },
   handler: async (ctx, args) => {
     await posthog.alias(ctx, {
       distinctId: args.distinctId,
       alias: args.alias,
+      disableGeoip: args.disableGeoip,
+    });
+    return { success: true };
+  },
+});
+
+export const testCaptureException = mutation({
+  args: {
+    errorMessage: v.string(),
+    errorType: v.optional(
+      v.union(v.literal("error"), v.literal("string"), v.literal("object")),
+    ),
+    distinctId: v.optional(v.string()),
+    additionalProperties: v.optional(v.any()),
+  },
+  handler: async (ctx, args) => {
+    let error: unknown;
+    switch (args.errorType ?? "error") {
+      case "error":
+        error = new Error(args.errorMessage);
+        break;
+      case "string":
+        error = args.errorMessage;
+        break;
+      case "object":
+        error = { message: args.errorMessage };
+        break;
+    }
+
+    await posthog.captureException(ctx, {
+      error,
+      distinctId: args.distinctId || undefined,
+      additionalProperties: args.additionalProperties,
     });
     return { success: true };
   },
@@ -67,65 +116,135 @@ export const testAlias = mutation({
 
 // --- Feature flag methods (actions) ---
 
+const featureFlagArgs = {
+  distinctId: v.string(),
+  flagKey: v.string(),
+  groups: v.optional(v.any()),
+  personProperties: v.optional(v.any()),
+  groupProperties: v.optional(v.any()),
+  sendFeatureFlagEvents: v.optional(v.boolean()),
+  disableGeoip: v.optional(v.boolean()),
+};
+
+function featureFlagOptions(args: {
+  groups?: unknown;
+  personProperties?: unknown;
+  groupProperties?: unknown;
+  sendFeatureFlagEvents?: boolean;
+  disableGeoip?: boolean;
+}) {
+  return {
+    groups: args.groups as Record<string, string> | undefined,
+    personProperties: args.personProperties as
+      | Record<string, string>
+      | undefined,
+    groupProperties: args.groupProperties as
+      | Record<string, Record<string, string>>
+      | undefined,
+    sendFeatureFlagEvents: args.sendFeatureFlagEvents,
+    disableGeoip: args.disableGeoip,
+  };
+}
+
 export const testGetFeatureFlag = action({
-  args: { distinctId: v.string(), flagKey: v.string() },
+  args: featureFlagArgs,
   handler: async (ctx, args) => {
     const value = await posthog.getFeatureFlag(ctx, {
       key: args.flagKey,
       distinctId: args.distinctId,
+      ...featureFlagOptions(args),
     });
     return { flagKey: args.flagKey, value };
   },
 });
 
 export const testIsFeatureEnabled = action({
-  args: { distinctId: v.string(), flagKey: v.string() },
+  args: featureFlagArgs,
   handler: async (ctx, args) => {
     const enabled = await posthog.isFeatureEnabled(ctx, {
       key: args.flagKey,
       distinctId: args.distinctId,
+      ...featureFlagOptions(args),
     });
     return { flagKey: args.flagKey, enabled };
   },
 });
 
 export const testGetFeatureFlagPayload = action({
-  args: { distinctId: v.string(), flagKey: v.string() },
+  args: {
+    ...featureFlagArgs,
+    matchValue: v.optional(v.union(v.boolean(), v.string())),
+  },
   handler: async (ctx, args) => {
     const payload = await posthog.getFeatureFlagPayload(ctx, {
       key: args.flagKey,
       distinctId: args.distinctId,
+      matchValue: args.matchValue,
+      ...featureFlagOptions(args),
     });
     return { flagKey: args.flagKey, payload };
   },
 });
 
 export const testGetFeatureFlagResult = action({
-  args: { distinctId: v.string(), flagKey: v.string() },
+  args: featureFlagArgs,
   handler: async (ctx, args) => {
     const result = await posthog.getFeatureFlagResult(ctx, {
       key: args.flagKey,
       distinctId: args.distinctId,
+      ...featureFlagOptions(args),
     });
     return { flagKey: args.flagKey, result };
   },
 });
 
 export const testGetAllFlags = action({
-  args: { distinctId: v.string() },
+  args: {
+    distinctId: v.string(),
+    groups: v.optional(v.any()),
+    personProperties: v.optional(v.any()),
+    groupProperties: v.optional(v.any()),
+    disableGeoip: v.optional(v.boolean()),
+    flagKeys: v.optional(v.array(v.string())),
+  },
   handler: async (ctx, args) => {
     const flags = await posthog.getAllFlags(ctx, {
       distinctId: args.distinctId,
+      groups: args.groups as Record<string, string> | undefined,
+      personProperties: args.personProperties as
+        | Record<string, string>
+        | undefined,
+      groupProperties: args.groupProperties as
+        | Record<string, Record<string, string>>
+        | undefined,
+      disableGeoip: args.disableGeoip,
+      flagKeys: args.flagKeys,
     });
     return { flags };
   },
 });
 
 export const testGetAllFlagsAndPayloads = action({
-  args: { distinctId: v.string() },
+  args: {
+    distinctId: v.string(),
+    groups: v.optional(v.any()),
+    personProperties: v.optional(v.any()),
+    groupProperties: v.optional(v.any()),
+    disableGeoip: v.optional(v.boolean()),
+    flagKeys: v.optional(v.array(v.string())),
+  },
   handler: async (ctx, args) => {
     const result = await posthog.getAllFlagsAndPayloads(ctx, {
       distinctId: args.distinctId,
+      groups: args.groups as Record<string, string> | undefined,
+      personProperties: args.personProperties as
+        | Record<string, string>
+        | undefined,
+      groupProperties: args.groupProperties as
+        | Record<string, Record<string, string>>
+        | undefined,
+      disableGeoip: args.disableGeoip,
+      flagKeys: args.flagKeys,
     });
     return result;
   },

--- a/example/convex/posthog.ts
+++ b/example/convex/posthog.ts
@@ -1,4 +1,14 @@
 import { PostHog } from "@posthog/convex";
 import { components } from "./_generated/api";
 
-export const posthog = new PostHog(components.posthog);
+export const posthog = new PostHog(components.posthog, {
+  beforeSend: (event) => {
+    return {
+      ...event,
+      properties: {
+        ...event.properties,
+        environment: "example-app",
+      },
+    };
+  },
+});

--- a/example/src/App.css
+++ b/example/src/App.css
@@ -1,42 +1,419 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+}
+
+:root {
+  --bg-0: #0b0f19;
+  --bg-1: #111827;
+  --bg-2: #1e293b;
+  --bg-3: #334155;
+  --border: #2d3748;
+  --border-focus: #475569;
+  --text-0: #f1f5f9;
+  --text-1: #cbd5e1;
+  --text-2: #94a3b8;
+  --text-3: #64748b;
+  --font-mono:
+    "SF Mono", "Cascadia Code", "Fira Code", "JetBrains Mono", ui-monospace,
+    monospace;
+  --font-sans: system-ui, -apple-system, sans-serif;
+  --radius: 6px;
+  --radius-lg: 10px;
+}
+
+body {
+  background: var(--bg-0);
+  color: var(--text-1);
+  font-family: var(--font-sans);
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+}
+
 #root {
-  max-width: 1280px;
+  max-width: 720px;
   margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
+  padding: 2rem 1.5rem 4rem;
+  text-align: left;
 }
 
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
+/* Header */
+.app-header {
+  margin-bottom: 2rem;
 }
 
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
+.app-header h1 {
+  font-size: 1.5rem;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  margin-bottom: 0.25rem;
+}
+
+.brand-post {
+  color: var(--text-0);
+}
+
+.brand-hog {
+  color: #f59e0b;
+}
+
+.brand-sep {
+  color: var(--text-3);
+  margin: 0 0.35em;
+  font-weight: 300;
+}
+
+.brand-convex {
+  color: var(--text-2);
+}
+
+.subtitle {
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  color: var(--text-3);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+/* Shared inputs */
+.shared-inputs {
+  background: var(--bg-1);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 1rem 1.25rem;
+  margin-bottom: 1.5rem;
+}
+
+.shared-inputs .field {
+  max-width: 320px;
+}
+
+/* Sections */
+.sections {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-bottom: 1.5rem;
+}
+
+.sdk-section {
+  background: var(--bg-1);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+
+.section-toggle {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.875rem 1.25rem;
+  background: none;
+  border: none;
+  color: var(--text-1);
+  font-family: var(--font-sans);
+  font-size: 0.9rem;
+  font-weight: 500;
+  cursor: pointer;
+  text-align: left;
+  transition: background 150ms;
+}
+
+.section-toggle:hover {
+  background: var(--bg-2);
+}
+
+.section-num {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 4px;
+  background: color-mix(in srgb, var(--accent) 15%, transparent);
+  color: var(--accent);
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  font-weight: 600;
+  flex-shrink: 0;
+}
+
+.section-label {
+  flex: 1;
+}
+
+.chevron {
+  color: var(--text-3);
+  transition: transform 200ms;
+  flex-shrink: 0;
+}
+
+.chevron.open {
+  transform: rotate(180deg);
+}
+
+.section-content {
+  padding: 0 1.25rem 1.25rem;
+  border-top: 1px solid var(--border);
+}
+
+/* Field grid */
+.field-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.75rem;
+  padding-top: 1rem;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.field--wide {
+  grid-column: 1 / -1;
+}
+
+.field-label {
+  font-size: 0.78rem;
+  font-weight: 500;
+  color: var(--text-2);
+}
+
+.field-hint {
+  color: var(--text-3);
+  font-weight: 400;
+  margin-left: 0.5em;
+  font-size: 0.72rem;
+}
+
+/* Inputs */
+input[type="text"],
+input:not([type]),
+textarea,
+select {
+  background: var(--bg-0);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text-0);
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  padding: 0.5rem 0.625rem;
+  outline: none;
+  transition:
+    border-color 150ms,
+    box-shadow 150ms;
+  width: 100%;
+}
+
+input:focus,
+textarea:focus,
+select:focus {
+  border-color: var(--accent, var(--border-focus));
+  box-shadow: 0 0 0 2px
+    color-mix(in srgb, var(--accent, var(--border-focus)) 15%, transparent);
+}
+
+textarea {
+  resize: vertical;
+  min-height: 2.5rem;
+  line-height: 1.4;
+}
+
+select {
+  cursor: pointer;
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath d='M3 4.5L6 7.5L9 4.5' fill='none' stroke='%2394a3b8' stroke-width='1.5'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 0.5rem center;
+  padding-right: 1.75rem;
+}
+
+::placeholder {
+  color: var(--text-3);
+}
+
+/* Checkboxes */
+.checkbox-row {
+  grid-column: 1 / -1;
+  display: flex;
+  gap: 1.25rem;
+  flex-wrap: wrap;
+}
+
+.checkbox {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.8rem;
+  color: var(--text-2);
+  cursor: pointer;
+  user-select: none;
+}
+
+.checkbox input[type="checkbox"] {
+  width: 1rem;
+  height: 1rem;
+  accent-color: var(--accent, #60a5fa);
+  cursor: pointer;
+}
+
+/* Action buttons */
+.actions {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 1rem;
+  justify-content: flex-end;
+}
+
+.actions--wrap {
+  flex-wrap: wrap;
+}
+
+.btn {
+  background: color-mix(in srgb, var(--accent, #60a5fa) 15%, var(--bg-2));
+  border: 1px solid
+    color-mix(in srgb, var(--accent, #60a5fa) 30%, var(--border));
+  border-radius: var(--radius);
+  color: var(--accent, #60a5fa);
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  font-weight: 500;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+  transition:
+    background 150ms,
+    border-color 150ms;
+  white-space: nowrap;
+}
+
+.btn:hover {
+  background: color-mix(in srgb, var(--accent, #60a5fa) 25%, var(--bg-2));
+  border-color: var(--accent, #60a5fa);
+}
+
+.btn:active {
+  background: color-mix(in srgb, var(--accent, #60a5fa) 35%, var(--bg-2));
+}
+
+.btn--loading {
+  opacity: 0.7;
+  cursor: wait;
+  animation: btn-pulse 1s ease-in-out infinite;
+}
+
+.btn--success {
+  background: color-mix(in srgb, #34d399 20%, var(--bg-2));
+  border-color: #34d399;
+  color: #34d399;
+  animation: btn-flash 400ms ease-out;
+}
+
+.btn--error {
+  background: color-mix(in srgb, #f87171 20%, var(--bg-2));
+  border-color: #f87171;
+  color: #f87171;
+  animation: btn-flash 400ms ease-out;
+}
+
+@keyframes btn-pulse {
+  0%,
+  100% {
+    opacity: 0.7;
   }
-  to {
-    transform: rotate(360deg);
+  50% {
+    opacity: 0.4;
   }
 }
 
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
+@keyframes btn-flash {
+  0% {
+    filter: brightness(1.5);
+  }
+  100% {
+    filter: brightness(1);
   }
 }
 
-.card {
-  padding: 2em;
+.btn--ghost {
+  background: transparent;
+  border-color: transparent;
 }
 
-.read-the-docs {
-  color: #888;
+.btn--ghost:hover {
+  background: var(--bg-2);
+  border-color: var(--border);
+}
+
+/* Log panel */
+.log-panel {
+  background: var(--bg-1);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+
+.log-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.625rem 1.25rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.log-title {
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--text-2);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.log-output {
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  line-height: 1.6;
+  color: var(--text-2);
+  padding: 1rem 1.25rem;
+  max-height: 300px;
+  overflow: auto;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.log-output::-webkit-scrollbar {
+  width: 6px;
+}
+
+.log-output::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.log-output::-webkit-scrollbar-thumb {
+  background: var(--bg-3);
+  border-radius: 3px;
+}
+
+/* Responsive */
+@media (max-width: 640px) {
+  #root {
+    padding: 1.5rem 1rem 3rem;
+  }
+
+  .field-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .field--wide {
+    grid-column: 1;
+  }
+
+  .actions {
+    flex-wrap: wrap;
+  }
 }

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,110 +1,692 @@
 import "./App.css";
 import { useAction, useMutation } from "convex/react";
 import { api } from "../convex/_generated/api";
-import { useState } from "react";
+import {
+  useState,
+  useRef,
+  useEffect,
+  useCallback,
+  type ReactNode,
+} from "react";
+
+function tryParseJson(
+  str: string,
+  addLog: (msg: string) => void,
+  field: string,
+): unknown | undefined {
+  const trimmed = str.trim();
+  if (!trimmed) return undefined;
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    addLog(`Parse error in ${field}: invalid JSON`);
+    return undefined;
+  }
+}
+
+function Section({
+  num,
+  title,
+  accent,
+  children,
+  defaultOpen = true,
+}: {
+  num: number;
+  title: string;
+  accent: string;
+  children: ReactNode;
+  defaultOpen?: boolean;
+}) {
+  const [open, setOpen] = useState(defaultOpen);
+  return (
+    <section
+      className="sdk-section"
+      style={{ "--accent": accent } as React.CSSProperties}
+    >
+      <button
+        className="section-toggle"
+        onClick={() => setOpen((o) => !o)}
+        aria-expanded={open}
+      >
+        <span className="section-num">{num}</span>
+        <span className="section-label">{title}</span>
+        <svg
+          className={`chevron ${open ? "open" : ""}`}
+          width="12"
+          height="12"
+          viewBox="0 0 12 12"
+        >
+          <path
+            d="M3 4.5L6 7.5L9 4.5"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.5"
+          />
+        </svg>
+      </button>
+      {open && <div className="section-content">{children}</div>}
+    </section>
+  );
+}
+
+function Field({
+  label,
+  hint,
+  children,
+  wide,
+}: {
+  label: string;
+  hint?: string;
+  children: ReactNode;
+  wide?: boolean;
+}) {
+  return (
+    <label className={`field ${wide ? "field--wide" : ""}`}>
+      <span className="field-label">
+        {label}
+        {hint && <span className="field-hint">{hint}</span>}
+      </span>
+      {children}
+    </label>
+  );
+}
 
 function App() {
+  // Shared
   const [distinctId, setDistinctId] = useState("user-123");
-  const [event, setEvent] = useState("test_event");
+
+  // 1. Capture
+  const [captureEvent, setCaptureEvent] = useState("button_clicked");
+  const [captureProps, setCaptureProps] = useState(
+    '{"plan":"pro","amount":99}',
+  );
+  const [captureGroups, setCaptureGroups] = useState('{"company":"acme"}');
+  const [captureSendFlags, setCaptureSendFlags] = useState(false);
+  const [captureGeoip, setCaptureGeoip] = useState(false);
+  const [captureUuid, setCaptureUuid] = useState("");
+  const [captureTimestamp, setCaptureTimestamp] = useState("");
+
+  // 2. Identify
+  const [identifyProps, setIdentifyProps] = useState(
+    '{"name":"Test User","email":"test@example.com","plan":"pro"}',
+  );
+  const [identifyGeoip, setIdentifyGeoip] = useState(false);
+
+  // 3. Group Identify
+  const [groupType, setGroupType] = useState("company");
+  const [groupKey, setGroupKey] = useState("acme");
+  const [groupProps, setGroupProps] = useState(
+    '{"industry":"Technology","size":100}',
+  );
+  const [groupDistinctId, setGroupDistinctId] = useState("");
+  const [groupGeoip, setGroupGeoip] = useState(false);
+
+  // 4. Alias
+  const [aliasValue, setAliasValue] = useState("anon-456");
+  const [aliasGeoip, setAliasGeoip] = useState(false);
+
+  // 5. Capture Exception
+  const [errorMsg, setErrorMsg] = useState("Something went wrong");
+  const [errorType, setErrorType] = useState<"error" | "string" | "object">(
+    "error",
+  );
+  const [exceptionProps, setExceptionProps] = useState('{"page":"/checkout"}');
+  const [exceptionDistinctId, setExceptionDistinctId] = useState("");
+
+  // 6. Feature Flags
   const [flagKey, setFlagKey] = useState("test-flag");
+  const [ffGroups, setFfGroups] = useState('{"company":"acme"}');
+  const [ffPersonProps, setFfPersonProps] = useState(
+    '{"email":"test@example.com"}',
+  );
+  const [ffGroupProps, setFfGroupProps] = useState(
+    '{"company":{"industry":"tech"}}',
+  );
+  const [ffSendEvents, setFfSendEvents] = useState(false);
+  const [ffGeoip, setFfGeoip] = useState(false);
+  const [ffMatchValue, setFfMatchValue] = useState("");
+  const [ffFlagKeys, setFfFlagKeys] = useState("");
+
+  // Log & button status
   const [log, setLog] = useState<string[]>([]);
+  const logRef = useRef<HTMLPreElement>(null);
+  const [btnStatus, setBtnStatus] = useState<
+    Record<string, "loading" | "success" | "error">
+  >({});
+  const addLog = useCallback(
+    (msg: string) =>
+      setLog((prev) => [...prev, `${new Date().toLocaleTimeString()} ${msg}`]),
+    [],
+  );
 
-  const addLog = (msg: string) =>
-    setLog((prev) => [...prev, `${new Date().toLocaleTimeString()} ${msg}`]);
+  useEffect(() => {
+    if (logRef.current) logRef.current.scrollTop = logRef.current.scrollHeight;
+  }, [log]);
 
-  // Fire-and-forget mutations
+  // Convex hooks
   const captureM = useMutation(api.example.testCapture);
   const identifyM = useMutation(api.example.testIdentify);
   const groupIdentifyM = useMutation(api.example.testGroupIdentify);
   const aliasM = useMutation(api.example.testAlias);
+  const captureExceptionM = useMutation(api.example.testCaptureException);
 
-  // Feature flag actions
   const getFeatureFlagA = useAction(api.example.testGetFeatureFlag);
   const isFeatureEnabledA = useAction(api.example.testIsFeatureEnabled);
   const getPayloadA = useAction(api.example.testGetFeatureFlagPayload);
   const getResultA = useAction(api.example.testGetFeatureFlagResult);
   const getAllFlagsA = useAction(api.example.testGetAllFlags);
-  const getAllFlagsPayloadsA = useAction(
-    api.example.testGetAllFlagsAndPayloads,
-  );
+  const getAllPayloadsA = useAction(api.example.testGetAllFlagsAndPayloads);
 
   const run = async (label: string, fn: () => Promise<unknown>) => {
+    setBtnStatus((s) => ({ ...s, [label]: "loading" }));
     addLog(`${label}...`);
+    let outcome: "success" | "error" = "success";
     try {
       const result = await fn();
       addLog(`${label} -> ${JSON.stringify(result)}`);
     } catch (e) {
       addLog(`${label} ERROR: ${e}`);
+      outcome = "error";
     }
+    setBtnStatus((s) => ({ ...s, [label]: outcome }));
+    setTimeout(() => {
+      setBtnStatus((s) => {
+        const next = { ...s };
+        if (next[label] === outcome) delete next[label];
+        return next;
+      });
+    }, 2000);
+  };
+
+  const btnProps = (label: string) => {
+    const status = btnStatus[label];
+    return {
+      className: `btn${status ? ` btn--${status}` : ""}`,
+      disabled: status === "loading",
+    };
+  };
+
+  const json = (str: string, field: string) => tryParseJson(str, addLog, field);
+
+  const ffArgs = () => ({
+    distinctId,
+    flagKey,
+    groups: json(ffGroups, "FF groups") as Record<string, string> | undefined,
+    personProperties: json(ffPersonProps, "FF person props") as
+      | Record<string, string>
+      | undefined,
+    groupProperties: json(ffGroupProps, "FF group props") as
+      | Record<string, Record<string, string>>
+      | undefined,
+    sendFeatureFlagEvents: ffSendEvents || undefined,
+    disableGeoip: ffGeoip || undefined,
+  });
+
+  const ffAllArgs = () => {
+    const keys = ffFlagKeys.trim()
+      ? ffFlagKeys
+          .split(",")
+          .map((k) => k.trim())
+          .filter(Boolean)
+      : undefined;
+    return {
+      distinctId,
+      groups: json(ffGroups, "FF groups") as Record<string, string> | undefined,
+      personProperties: json(ffPersonProps, "FF person props") as
+        | Record<string, string>
+        | undefined,
+      groupProperties: json(ffGroupProps, "FF group props") as
+        | Record<string, Record<string, string>>
+        | undefined,
+      disableGeoip: ffGeoip || undefined,
+      flagKeys: keys,
+    };
   };
 
   return (
-    <>
-      <h1>PostHog Convex Component</h1>
+    <div className="app">
+      <header className="app-header">
+        <h1>
+          <span className="brand-post">Post</span>
+          <span className="brand-hog">Hog</span>
+          <span className="brand-sep">&times;</span>
+          <span className="brand-convex">Convex</span>
+        </h1>
+        <p className="subtitle">SDK Explorer</p>
+      </header>
 
-      <div className="card">
-        <div style={{ display: "flex", flexDirection: "column", gap: "0.5rem", marginBottom: "1rem" }}>
-          <label>
-            Distinct ID
-            <input value={distinctId} onChange={(e) => setDistinctId(e.target.value)} style={{ marginLeft: "0.5rem" }} />
-          </label>
-          <label>
-            Event name
-            <input value={event} onChange={(e) => setEvent(e.target.value)} style={{ marginLeft: "0.5rem" }} />
-          </label>
-          <label>
-            Flag key
-            <input value={flagKey} onChange={(e) => setFlagKey(e.target.value)} style={{ marginLeft: "0.5rem" }} />
-          </label>
-        </div>
-
-        <h3>Fire-and-forget (mutations)</h3>
-        <div style={{ display: "flex", gap: "0.5rem", flexWrap: "wrap", marginBottom: "1rem" }}>
-          <button onClick={() => run("capture", () => captureM({ distinctId, event }))}>
-            capture
-          </button>
-          <button onClick={() => run("identify", () => identifyM({ distinctId }))}>
-            identify
-          </button>
-          <button onClick={() => run("groupIdentify", () => groupIdentifyM({ groupType: "company", groupKey: "acme" }))}>
-            groupIdentify
-          </button>
-          <button onClick={() => run("alias", () => aliasM({ distinctId, alias: "anon-456" }))}>
-            alias
-          </button>
-        </div>
-
-        <h3>Feature flags (actions)</h3>
-        <div style={{ display: "flex", gap: "0.5rem", flexWrap: "wrap", marginBottom: "1rem" }}>
-          <button onClick={() => run("getFeatureFlag", () => getFeatureFlagA({ distinctId, flagKey }))}>
-            getFeatureFlag
-          </button>
-          <button onClick={() => run("isFeatureEnabled", () => isFeatureEnabledA({ distinctId, flagKey }))}>
-            isFeatureEnabled
-          </button>
-          <button onClick={() => run("getFeatureFlagPayload", () => getPayloadA({ distinctId, flagKey }))}>
-            getFeatureFlagPayload
-          </button>
-          <button onClick={() => run("getFeatureFlagResult", () => getResultA({ distinctId, flagKey }))}>
-            getFeatureFlagResult
-          </button>
-          <button onClick={() => run("getAllFlags", () => getAllFlagsA({ distinctId }))}>
-            getAllFlags
-          </button>
-          <button onClick={() => run("getAllFlagsAndPayloads", () => getAllFlagsPayloadsA({ distinctId }))}>
-            getAllFlagsAndPayloads
-          </button>
-        </div>
-
-        <h3>Log</h3>
-        <pre style={{ textAlign: "left", maxHeight: "300px", overflow: "auto", fontSize: "0.8rem" }}>
-          {log.length ? log.join("\n") : "Click a button to test..."}
-        </pre>
-        <button onClick={() => setLog([])} style={{ marginTop: "0.5rem" }}>
-          Clear log
-        </button>
+      <div className="shared-inputs">
+        <Field label="Distinct ID">
+          <input
+            type="text"
+            value={distinctId}
+            onChange={(e) => setDistinctId(e.target.value)}
+            placeholder="user-123"
+          />
+        </Field>
       </div>
-    </>
+
+      <div className="sections">
+        {/* 1. Event Capture */}
+        <Section num={1} title="Event Capture" accent="#60a5fa">
+          <div className="field-grid">
+            <Field label="Event name">
+              <input
+                value={captureEvent}
+                onChange={(e) => setCaptureEvent(e.target.value)}
+              />
+            </Field>
+            <Field label="UUID" hint="optional">
+              <input
+                value={captureUuid}
+                onChange={(e) => setCaptureUuid(e.target.value)}
+                placeholder="auto-generated"
+              />
+            </Field>
+            <Field label="Properties" hint="JSON" wide>
+              <textarea
+                value={captureProps}
+                onChange={(e) => setCaptureProps(e.target.value)}
+                rows={2}
+              />
+            </Field>
+            <Field label="Groups" hint="JSON" wide>
+              <textarea
+                value={captureGroups}
+                onChange={(e) => setCaptureGroups(e.target.value)}
+                rows={2}
+              />
+            </Field>
+            <Field label="Timestamp" hint="ISO 8601">
+              <input
+                value={captureTimestamp}
+                onChange={(e) => setCaptureTimestamp(e.target.value)}
+                placeholder="2024-01-01T00:00:00Z"
+              />
+            </Field>
+            <div className="checkbox-row">
+              <label className="checkbox">
+                <input
+                  type="checkbox"
+                  checked={captureSendFlags}
+                  onChange={(e) => setCaptureSendFlags(e.target.checked)}
+                />
+                Send feature flags
+              </label>
+              <label className="checkbox">
+                <input
+                  type="checkbox"
+                  checked={captureGeoip}
+                  onChange={(e) => setCaptureGeoip(e.target.checked)}
+                />
+                Disable GeoIP
+              </label>
+            </div>
+          </div>
+          <div className="actions">
+            <button
+              {...btnProps("capture")}
+              onClick={() =>
+                run("capture", () =>
+                  captureM({
+                    distinctId,
+                    event: captureEvent,
+                    properties: json(captureProps, "properties"),
+                    groups: json(captureGroups, "groups"),
+                    sendFeatureFlags: captureSendFlags || undefined,
+                    timestamp: captureTimestamp || undefined,
+                    uuid: captureUuid || undefined,
+                    disableGeoip: captureGeoip || undefined,
+                  }),
+                )
+              }
+            >
+              Capture
+            </button>
+          </div>
+        </Section>
+
+        {/* 2. Identify */}
+        <Section num={2} title="Identify" accent="#34d399">
+          <div className="field-grid">
+            <Field
+              label="Properties"
+              hint="JSON -- sent as $set properties"
+              wide
+            >
+              <textarea
+                value={identifyProps}
+                onChange={(e) => setIdentifyProps(e.target.value)}
+                rows={3}
+              />
+            </Field>
+            <div className="checkbox-row">
+              <label className="checkbox">
+                <input
+                  type="checkbox"
+                  checked={identifyGeoip}
+                  onChange={(e) => setIdentifyGeoip(e.target.checked)}
+                />
+                Disable GeoIP
+              </label>
+            </div>
+          </div>
+          <div className="actions">
+            <button
+              {...btnProps("identify")}
+              onClick={() =>
+                run("identify", () =>
+                  identifyM({
+                    distinctId,
+                    properties: json(identifyProps, "properties"),
+                    disableGeoip: identifyGeoip || undefined,
+                  }),
+                )
+              }
+            >
+              Identify
+            </button>
+          </div>
+        </Section>
+
+        {/* 3. Group Identify */}
+        <Section num={3} title="Group Identify" accent="#a78bfa">
+          <div className="field-grid">
+            <Field label="Group type">
+              <input
+                value={groupType}
+                onChange={(e) => setGroupType(e.target.value)}
+              />
+            </Field>
+            <Field label="Group key">
+              <input
+                value={groupKey}
+                onChange={(e) => setGroupKey(e.target.value)}
+              />
+            </Field>
+            <Field label="Properties" hint="JSON" wide>
+              <textarea
+                value={groupProps}
+                onChange={(e) => setGroupProps(e.target.value)}
+                rows={2}
+              />
+            </Field>
+            <Field label="Distinct ID" hint="optional override">
+              <input
+                value={groupDistinctId}
+                onChange={(e) => setGroupDistinctId(e.target.value)}
+                placeholder="uses shared ID if empty"
+              />
+            </Field>
+            <div className="checkbox-row">
+              <label className="checkbox">
+                <input
+                  type="checkbox"
+                  checked={groupGeoip}
+                  onChange={(e) => setGroupGeoip(e.target.checked)}
+                />
+                Disable GeoIP
+              </label>
+            </div>
+          </div>
+          <div className="actions">
+            <button
+              {...btnProps("groupIdentify")}
+              onClick={() =>
+                run("groupIdentify", () =>
+                  groupIdentifyM({
+                    groupType,
+                    groupKey,
+                    properties: json(groupProps, "properties"),
+                    distinctId: groupDistinctId || undefined,
+                    disableGeoip: groupGeoip || undefined,
+                  }),
+                )
+              }
+            >
+              Group Identify
+            </button>
+          </div>
+        </Section>
+
+        {/* 4. Alias */}
+        <Section num={4} title="Alias" accent="#fb923c">
+          <div className="field-grid">
+            <Field label="Alias">
+              <input
+                value={aliasValue}
+                onChange={(e) => setAliasValue(e.target.value)}
+              />
+            </Field>
+            <div className="checkbox-row">
+              <label className="checkbox">
+                <input
+                  type="checkbox"
+                  checked={aliasGeoip}
+                  onChange={(e) => setAliasGeoip(e.target.checked)}
+                />
+                Disable GeoIP
+              </label>
+            </div>
+          </div>
+          <div className="actions">
+            <button
+              {...btnProps("alias")}
+              onClick={() =>
+                run("alias", () =>
+                  aliasM({
+                    distinctId,
+                    alias: aliasValue,
+                    disableGeoip: aliasGeoip || undefined,
+                  }),
+                )
+              }
+            >
+              Create Alias
+            </button>
+          </div>
+        </Section>
+
+        {/* 5. Capture Exception */}
+        <Section num={5} title="Capture Exception" accent="#f87171">
+          <div className="field-grid">
+            <Field label="Error message">
+              <input
+                value={errorMsg}
+                onChange={(e) => setErrorMsg(e.target.value)}
+              />
+            </Field>
+            <Field label="Error type">
+              <select
+                value={errorType}
+                onChange={(e) =>
+                  setErrorType(e.target.value as "error" | "string" | "object")
+                }
+              >
+                <option value="error">Error object</option>
+                <option value="string">String</option>
+                <option value="object">Object with message</option>
+              </select>
+            </Field>
+            <Field label="Additional properties" hint="JSON" wide>
+              <textarea
+                value={exceptionProps}
+                onChange={(e) => setExceptionProps(e.target.value)}
+                rows={2}
+              />
+            </Field>
+            <Field label="Distinct ID" hint="optional override">
+              <input
+                value={exceptionDistinctId}
+                onChange={(e) => setExceptionDistinctId(e.target.value)}
+                placeholder="uses shared ID if empty"
+              />
+            </Field>
+          </div>
+          <div className="actions">
+            <button
+              {...btnProps("captureException")}
+              onClick={() =>
+                run("captureException", () =>
+                  captureExceptionM({
+                    errorMessage: errorMsg,
+                    errorType,
+                    distinctId: exceptionDistinctId || undefined,
+                    additionalProperties: json(
+                      exceptionProps,
+                      "additional properties",
+                    ),
+                  }),
+                )
+              }
+            >
+              Capture Exception
+            </button>
+          </div>
+        </Section>
+
+        {/* 6. Feature Flags */}
+        <Section num={6} title="Feature Flags" accent="#22d3ee">
+          <div className="field-grid">
+            <Field label="Flag key">
+              <input
+                value={flagKey}
+                onChange={(e) => setFlagKey(e.target.value)}
+              />
+            </Field>
+            <Field label="Match value" hint="for payload">
+              <input
+                value={ffMatchValue}
+                onChange={(e) => setFfMatchValue(e.target.value)}
+                placeholder="boolean or string"
+              />
+            </Field>
+            <Field label="Groups" hint="JSON" wide>
+              <textarea
+                value={ffGroups}
+                onChange={(e) => setFfGroups(e.target.value)}
+                rows={2}
+              />
+            </Field>
+            <Field label="Person properties" hint="JSON" wide>
+              <textarea
+                value={ffPersonProps}
+                onChange={(e) => setFfPersonProps(e.target.value)}
+                rows={2}
+              />
+            </Field>
+            <Field label="Group properties" hint="JSON" wide>
+              <textarea
+                value={ffGroupProps}
+                onChange={(e) => setFfGroupProps(e.target.value)}
+                rows={2}
+              />
+            </Field>
+            <Field
+              label="Flag keys filter"
+              hint="comma-separated, for getAll"
+              wide
+            >
+              <input
+                value={ffFlagKeys}
+                onChange={(e) => setFfFlagKeys(e.target.value)}
+                placeholder="flag-1, flag-2"
+              />
+            </Field>
+            <div className="checkbox-row">
+              <label className="checkbox">
+                <input
+                  type="checkbox"
+                  checked={ffSendEvents}
+                  onChange={(e) => setFfSendEvents(e.target.checked)}
+                />
+                Send flag events
+              </label>
+              <label className="checkbox">
+                <input
+                  type="checkbox"
+                  checked={ffGeoip}
+                  onChange={(e) => setFfGeoip(e.target.checked)}
+                />
+                Disable GeoIP
+              </label>
+            </div>
+          </div>
+          <div className="actions actions--wrap">
+            <button
+              {...btnProps("getFeatureFlag")}
+              onClick={() =>
+                run("getFeatureFlag", () => getFeatureFlagA(ffArgs()))
+              }
+            >
+              getFeatureFlag
+            </button>
+            <button
+              {...btnProps("isFeatureEnabled")}
+              onClick={() =>
+                run("isFeatureEnabled", () => isFeatureEnabledA(ffArgs()))
+              }
+            >
+              isFeatureEnabled
+            </button>
+            <button
+              {...btnProps("getFeatureFlagPayload")}
+              onClick={() => {
+                const args = ffArgs();
+                const mv = ffMatchValue.trim();
+                let matchValue: boolean | string | undefined;
+                if (mv === "true") matchValue = true;
+                else if (mv === "false") matchValue = false;
+                else if (mv) matchValue = mv;
+                run("getFeatureFlagPayload", () =>
+                  getPayloadA({ ...args, matchValue }),
+                );
+              }}
+            >
+              getFeatureFlagPayload
+            </button>
+            <button
+              {...btnProps("getFeatureFlagResult")}
+              onClick={() =>
+                run("getFeatureFlagResult", () => getResultA(ffArgs()))
+              }
+            >
+              getFeatureFlagResult
+            </button>
+            <button
+              {...btnProps("getAllFlags")}
+              onClick={() =>
+                run("getAllFlags", () => getAllFlagsA(ffAllArgs()))
+              }
+            >
+              getAllFlags
+            </button>
+            <button
+              {...btnProps("getAllFlagsAndPayloads")}
+              onClick={() =>
+                run("getAllFlagsAndPayloads", () =>
+                  getAllPayloadsA(ffAllArgs()),
+                )
+              }
+            >
+              getAllFlagsAndPayloads
+            </button>
+          </div>
+        </Section>
+      </div>
+
+      <div className="log-panel">
+        <div className="log-header">
+          <span className="log-title">Log</span>
+          <button className="btn btn--ghost" onClick={() => setLog([])}>
+            Clear
+          </button>
+        </div>
+        <pre className="log-output" ref={logRef}>
+          {log.length ? log.join("\n") : "Ready. Click any action to test."}
+        </pre>
+      </div>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary

- Rewrite example app to exercise every SDK method with all available parameters
- Add 6 collapsible sections (capture, identify, group identify, alias, capture exception, feature flags) with editable inputs for every option
- Add dark developer-tool theme with button feedback states and timestamped log panel
- Replace 2 basic existence tests with 38 integration tests covering all SDK methods

## Test plan

- [x] All 38 tests pass (`npx vitest run`)
- [ ] Run `npm run dev` in the example directory and click through each section
- [ ] Verify events arrive in PostHog with correct properties