### PR TITLE
Add identify callback for automatic user resolution

### DIFF
--- a/example/convex/example.ts
+++ b/example/convex/example.ts
@@ -3,10 +3,13 @@ import { action, mutation } from "./_generated/server.js";
 import { v } from "convex/values";
 
 // --- Fire-and-forget methods (mutations) ---
+// When the identify callback is configured, distinctId is resolved automatically
+// from the signed-in user. Pass distinctId explicitly to override or when the
+// user is not signed in.
 
 export const testCapture = mutation({
   args: {
-    distinctId: v.string(),
+    distinctId: v.optional(v.string()),
     event: v.string(),
     properties: v.optional(v.any()),
     groups: v.optional(v.any()),
@@ -32,7 +35,7 @@ export const testCapture = mutation({
 
 export const testIdentify = mutation({
   args: {
-    distinctId: v.string(),
+    distinctId: v.optional(v.string()),
     properties: v.optional(v.any()),
     disableGeoip: v.optional(v.boolean()),
   },
@@ -68,7 +71,7 @@ export const testGroupIdentify = mutation({
 
 export const testAlias = mutation({
   args: {
-    distinctId: v.string(),
+    distinctId: v.optional(v.string()),
     alias: v.string(),
     disableGeoip: v.optional(v.boolean()),
   },
@@ -117,7 +120,7 @@ export const testCaptureException = mutation({
 // --- Feature flag methods (actions) ---
 
 const featureFlagArgs = {
-  distinctId: v.string(),
+  distinctId: v.optional(v.string()),
   flagKey: v.string(),
   groups: v.optional(v.any()),
   personProperties: v.optional(v.any()),
@@ -200,7 +203,7 @@ export const testGetFeatureFlagResult = action({
 
 export const testGetAllFlags = action({
   args: {
-    distinctId: v.string(),
+    distinctId: v.optional(v.string()),
     groups: v.optional(v.any()),
     personProperties: v.optional(v.any()),
     groupProperties: v.optional(v.any()),
@@ -226,7 +229,7 @@ export const testGetAllFlags = action({
 
 export const testGetAllFlagsAndPayloads = action({
   args: {
-    distinctId: v.string(),
+    distinctId: v.optional(v.string()),
     groups: v.optional(v.any()),
     personProperties: v.optional(v.any()),
     groupProperties: v.optional(v.any()),

--- a/example/convex/posthog.ts
+++ b/example/convex/posthog.ts
@@ -2,6 +2,13 @@ import { PostHog } from "@posthog/convex";
 import { components } from "./_generated/api";
 
 export const posthog = new PostHog(components.posthog, {
+  // Automatically resolve the current user's identity from Convex auth.
+  // Falls back to an explicit distinctId if the user is not signed in.
+  identify: async (ctx) => {
+    const identity = await ctx.auth?.getUserIdentity();
+    if (!identity) return null;
+    return { distinctId: identity.subject };
+  },
   beforeSend: (event) => {
     return {
       ...event,


### PR DESCRIPTION
## Summary

- Add an `identify` callback option to the `PostHog` constructor that resolves `distinctId` from Convex auth context (e.g. `ctx.auth.getUserIdentity()`)
- Make `distinctId` optional on all methods — the callback result takes precedence, with the explicit argument as fallback
- `captureException` gracefully handles missing identity (continues without `distinctId`)

## How it works

```typescript
const posthog = new PostHog(components.posthog, {
  identify: async (ctx) => {
    const identity = await ctx.auth?.getUserIdentity();
    if (!identity) return null;
    return { distinctId: identity.subject };
  },
});

// distinctId resolved automatically from signed-in user
await posthog.capture(ctx, { event: "page_view" });

// explicit distinctId still works as fallback
await posthog.capture(ctx, { distinctId: "anon-123", event: "page_view" });
```

Resolution order: identify callback → explicit `distinctId` → error.

## Test plan

- [x] Existing tests pass (explicit `distinctId` still works)
- [x] New tests cover callback resolution, fallback, error case, precedence, and integration with all method types
- [x] TypeScript compiles with no errors