### PR TITLE
fix: Add repo to changeset changelog config

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
-    "changelog": "@changesets/changelog-github",
+    "changelog": ["@changesets/changelog-github", { "repo": "PostHog/posthog-convex" }],
     "commit": false,
     "fixed": [],
     "linked": [],


### PR DESCRIPTION
## Problem

Release workflow failed because `@changesets/changelog-github` requires a `repo` option to generate PR links in the changelog.

## Changes

Add `{ "repo": "PostHog/posthog-convex" }` to the changelog config in `.changeset/config.json`.